### PR TITLE
optionaly construct tree from all available relationships

### DIFF
--- a/obogo/io_obo.py
+++ b/obogo/io_obo.py
@@ -49,7 +49,14 @@ class Buffer:
     @property    
     def is_obsolete(self):
         return 'is_obsolete' in self.data
-            
+
+    def relationship_iter(self, relationships):
+        relationship_dic = {}
+        for rel in relationships:
+            if rel in self.data:
+                relationship_dic[rel] = self.data[rel]
+        return relationship_dic    
+
     def is_a_iter(self):
         if 'is_a' in self.data:
             return self.data['is_a']
@@ -92,10 +99,13 @@ def obo_node_buffer_iter(fp:TextIOWrapper):
             if not m:
                 m = re.search(r'^(name): (.+)', line)
             if not m:
+                m = re.search(r'^relationship: ([\S]+) ([\S]+)', line)
+            if not m:
                 m = re.search(r'^(.+): ([\S]+)', line)
                 if not m:
                     raise ValueError(line)
             buffer[ m[1] ] = m[2]
+            
 
     # pop trailer
     if buffer:

--- a/obogo/tree.py
+++ b/obogo/tree.py
@@ -277,15 +277,16 @@ class GO_tree(nx.DiGraph):
                                   True if percol_type in ["both", "measured"]   else self.percolated_status[1] )
 
 # MAybe move to io
-def reader(obo_file_path:str, keep_obsolete=True, ns=None)-> DiGraph :
+def reader(obo_file_path:str, keep_obsolete=True, ns=None, relationships_to_consider = ['is_a'])-> DiGraph :
     G = GO_tree() #nx.DiGraph()
 
     for node_buffer in obo_node_buffer_iter(open(obo_file_path, 'r')):
         if not keep_obsolete and node_buffer.is_obsolete:
             continue
         G.add_node(node_buffer['id'], **node_buffer.nx_node_param)
-        for node_parent_id in node_buffer.is_a_iter():
-            G.add_edge(node_parent_id, node_buffer['id'], type='is_a')
+        for relationship, node_parents in node_buffer.relationship_iter(relationships_to_consider).items():
+            for node_parent_id in node_parents:
+                G.add_edge(node_parent_id, node_buffer['id'], type=relationship)
 
     return G
 


### PR DESCRIPTION
I propose a way to construct the tree not just from 'is_a' relationships, but from all available relationships in the original obo. 
We precise the type(s) of relationship to consider for the tree construction as an argument of tree.reader() function 